### PR TITLE
Fix output path

### DIFF
--- a/pipelines/brochures/Cargo.toml
+++ b/pipelines/brochures/Cargo.toml
@@ -5,4 +5,6 @@ edition = "2021"
 
 [dependencies]
 color-eyre = "0.6.2"
+tracing = "0.1.36"
+tracing-subscriber = "0.3.15"
 walkdir = "2.3.2"


### PR DESCRIPTION
Fixes the output path of the brochure pipeline.

Drive-by:
- Adds logging to the brochure pipeline.
