### PR TITLE
Implement incubator workflow

### DIFF
--- a/.github/workflows/incubator.yml
+++ b/.github/workflows/incubator.yml
@@ -1,0 +1,40 @@
+name: incubator
+
+defaults:
+  run:
+    working-directory: incubator
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/incubator.yml"
+      - "incubator/**"
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    paths:
+      - ".github/workflows/incubator.yml"
+      - "incubator/**"
+    branches:
+      - main
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3


### PR DESCRIPTION
Implements the missing workflow for the incubator.

The incubator projects don't need a CI per say, but they do need a
GitHub workflow with a placeholder for the lint, test and build jobs.

Fixes #33

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
