### PR TITLE
Fix infrastructure value types

### DIFF
--- a/bnacore/src/bundle.rs
+++ b/bnacore/src/bundle.rs
@@ -170,8 +170,8 @@ impl Bundle {
         for (group_name, files) in groups.iter() {
             // Zip the group.
             let group_name = format!("{group_name}.zip");
-            let group_path = bundle_dir.join(&group_name);
-            let group_file = std::fs::File::create(&group_path).unwrap();
+            let group_path = bundle_dir.join(group_name);
+            let group_file = std::fs::File::create(group_path).unwrap();
             let mut group_zip = zip::ZipWriter::new(group_file);
 
             // Add each file from the group.
@@ -217,8 +217,8 @@ impl Bundle {
         for (group_name, files) in groups.iter() {
             // Zip the group.
             let group_name = format!("{group_name}.gz");
-            let group_path = bundle_dir.join(&group_name);
-            let group_file = std::fs::File::create(&group_path).unwrap();
+            let group_path = bundle_dir.join(group_name);
+            let group_file = std::fs::File::create(group_path).unwrap();
             let options = EncodeOptions::new().no_compression();
             let mut archive = Encoder::with_options(group_file, options).unwrap();
 

--- a/bnacore/src/combine.rs
+++ b/bnacore/src/combine.rs
@@ -32,8 +32,8 @@ where
 
         documents_pages.extend(
             doc.get_pages()
-                .into_iter()
-                .map(|(_, object_id)| {
+                .into_values()
+                .map(|object_id| {
                     if !first {
                         let bookmark = Bookmark::new(
                             format!("Page_{}", pagenum),
@@ -143,8 +143,8 @@ where
         dictionary.set(
             "Kids",
             documents_pages
-                .into_iter()
-                .map(|(object_id, _)| Object::Reference(object_id))
+                .into_keys()
+                .map(|(object_id, other)| Object::Reference((object_id, other)))
                 .collect::<Vec<_>>(),
         );
         document

--- a/bnacore/src/scorecard.rs
+++ b/bnacore/src/scorecard.rs
@@ -317,9 +317,9 @@ pub struct ShortScoreCard {
 
     // Infrastructure
     #[pyo3(get, set)]
-    pub lsm: u8,
+    pub lsm: u32,
     #[pyo3(get, set)]
-    pub hsm: u8,
+    pub hsm: u32,
 }
 
 impl From<&ScoreCard> for ShortScoreCard {
@@ -350,12 +350,12 @@ impl From<&ScoreCard> for ShortScoreCard {
                 .infrastructure
                 .low_stress_miles
                 .unwrap_or_default()
-                .round() as u8,
+                .round() as u32,
             hsm: sc
                 .infrastructure
                 .high_stress_miles
                 .unwrap_or_default()
-                .round() as u8,
+                .round() as u32,
         }
     }
 }


### PR DESCRIPTION
This patch fixes the types used in the Infrstructure struct, which were
set too small.
