### PR TITLE
Fix Python function argument order

### DIFF
--- a/bnacore/src/scorecard.rs
+++ b/bnacore/src/scorecard.rs
@@ -64,11 +64,11 @@ impl City {
     pub fn new(
         name: &str,
         country: &str,
-        state: Option<&str>,
         uuid: &str,
         population: u32,
         ratings: f64,
         ratings_rounded: u8,
+        state: Option<&str>,
     ) -> Self {
         City {
             name: name.into(),


### PR DESCRIPTION
Ensures that optional arguments are placed last, as they cannot appear
in the middle of the signature in Python.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
