### PR TITLE
Update Rust GitHub actions

### DIFF
--- a/.github/workflows/bnacore.yml
+++ b/.github/workflows/bnacore.yml
@@ -17,8 +17,6 @@ on:
     paths:
       - ".github/workflows/bnacore.yml"
       - "bnacore/**"
-    branches:
-      - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
@@ -27,48 +25,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy rustfmt
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path bnacore/Cargo.toml --check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path bnacore/Cargo.toml -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path bnacore/Cargo.toml
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo check
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path bnacore/Cargo.toml
+      - run: cargo test
 
   build:
     name: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path bnacore/Cargo.toml
+      - run: cargo build

--- a/.github/workflows/incubator.yml
+++ b/.github/workflows/incubator.yml
@@ -17,8 +17,6 @@ on:
     paths:
       - ".github/workflows/incubator.yml"
       - "incubator/**"
-    branches:
-      - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 

--- a/.github/workflows/pipelines-brochures.yml
+++ b/.github/workflows/pipelines-brochures.yml
@@ -17,8 +17,6 @@ on:
     paths:
       - ".github/workflows/pipelines-brochures.yml"
       - "pipelines/brochures/**"
-    branches:
-      - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
@@ -27,40 +25,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy rustfmt
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path pipelines/brochures/Cargo.toml --check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path pipelines/brochures/Cargo.toml -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path pipelines/brochures/Cargo.toml
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo check
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path pipelines/brochures/Cargo.toml
+      - run: cargo test
 
   build:
     name: build
@@ -68,7 +47,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path pipelines/brochures/Cargo.toml
+      - run: cargo build

--- a/.github/workflows/pipelines-retrieve.yml
+++ b/.github/workflows/pipelines-retrieve.yml
@@ -17,8 +17,6 @@ on:
     paths:
       - ".github/workflows/pipelines-retrieve.yml"
       - "pipelines/retrieve/**"
-    branches:
-      - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
@@ -27,48 +25,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy rustfmt
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path pipelines/retrieve/Cargo.toml --check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path pipelines/retrieve/Cargo.toml -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path pipelines/retrieve/Cargo.toml
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo check
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path pipelines/retrieve/Cargo.toml
+      - run: cargo test
 
   build:
     name: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path pipelines/retrieve/Cargo.toml
+      - run: cargo build

--- a/.github/workflows/spokes.yml
+++ b/.github/workflows/spokes.yml
@@ -27,48 +27,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy rustfmt
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path spokes/Cargo.toml --check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path spokes/Cargo.toml -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path spokes/Cargo.toml
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo check
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path spokes/Cargo.toml
+      - run: cargo test
 
   build:
     name: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path spokes/Cargo.toml
+      - run: cargo build


### PR DESCRIPTION
Replaces the Rust GitHub actions coming from `action-rs` as they are
unmaintained. This was also an opportunity to simplify the run calls as
well.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
