### PR TITLE
Update CI to handle Windows platform

### DIFF
--- a/incubator/bnapi/api/src/main.rs
+++ b/incubator/bnapi/api/src/main.rs
@@ -213,12 +213,12 @@ async fn main() -> Result<(), Report> {
                 env!("CARGO_MANIFEST_DIR"),
                 "/static"
             )))
-            .handle_error(|error: std::io::Error| async move {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Unhandled internal error: {}", error),
-                )
-            }),
+            // .handle_error(|error: std::io::Error| async move {
+            //     (
+            //         StatusCode::INTERNAL_SERVER_ERROR,
+            //         format!("Unhandled internal error: {}", error),
+            //     )
+            // }),
         )
         .layer(ServiceBuilder::new().layer(CookieManagerLayer::new()))
         .layer(

--- a/pipelines/brochures/Cargo.toml
+++ b/pipelines/brochures/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bnacore = { path = "../../bnacore" }
 color-eyre = "0.6.2"
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"


### PR DESCRIPTION
Updates the CI to run the linters on both Ubuntu and Windows.

Drive-bys:
- Fixes CI violations.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
