### PR TITLE
Add missing workflow path

### DIFF
--- a/.github/workflows/lambda-deployment-staging.yml
+++ b/.github/workflows/lambda-deployment-staging.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/lambda-deployment-staging.yml"
       - "lambdas/**"
 
 permissions:


### PR DESCRIPTION
Adds the missing path for the deployment staging workflow.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
