### PR TITLE
Fix brochure pipeline

### DIFF
--- a/bnacore/src/template.rs
+++ b/bnacore/src/template.rs
@@ -87,20 +87,20 @@ pub fn render(
     let mut files: Vec<PathBuf> = Vec::new();
     for result in csv_reader.deserialize() {
         let record: Record = result?;
-
-        // Construct the name of the output file.
-        let item_name = match field_based_name.clone() {
-            Some(fields) => {
-                let v = fields
-                    .clone()
-                    .iter()
-                    .map(|f| record[f].clone())
-                    .map(|f| f.replace(' ', "_"))
-                    .collect::<Vec<String>>();
-                v.join(sep).to_lowercase()
-            }
-            None => record.values().next().unwrap().to_owned().to_lowercase(),
-        };
+        let mut item_name = String::new();
+        if let Some(fields) = &field_based_name {
+            let field_values = fields
+                .iter()
+                .map(|f| record[f].clone())
+                .collect::<Vec<String>>();
+            let name = field_values.join(sep);
+            item_name = name
+                .to_lowercase()
+                .replace(' ', "_")
+                .chars()
+                .filter(|c| c.is_alphabetic() || *c == '-' || *c == '_' || *c == '.')
+                .collect::<String>();
+        }
         let mut item = item_name.clone();
         item.push_str(".svg");
 
@@ -225,11 +225,11 @@ pub fn export_with_cairosvg(srcs: &[PathBuf]) {
 pub fn export_with_svg2pdf(srcs: &[PathBuf]) {
     for src in srcs {
         // Prepare the input/output values from the src argument.
-        let (in_svg, _out_pdf) = get_in_out_file(src);
+        let (in_svg, out_pdf) = get_in_out_file(src);
 
         // Prepare the command.
         let program = "svg2pdf";
-        let args = vec![in_svg];
+        let args = vec![in_svg, out_pdf];
 
         export_with(program, &args);
     }

--- a/pipelines/brochures/src/main.rs
+++ b/pipelines/brochures/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Report> {
     let asset_dir = top_dir.join("assets");
     let output_dir = top_dir.join("pipelines/brochures/output");
     let brochure_template = asset_dir
-        .join("visuals/template-scorecard-pg1-v23.1.svg")
+        .join("visuals/template-scorecard-pg1-v23.2.svg")
         .canonicalize()?;
     let brochure_information_page = asset_dir.join("visuals/template-scorecard-pg2-v23.1.pdf");
     let city_ratings = asset_dir
@@ -78,6 +78,8 @@ fn main() -> Result<(), Report> {
         .arg("st")
         .arg("--field")
         .arg("ci")
+        .arg("--exporter")
+        .arg("svg2pdf")
         .arg(&brochure_template_copy)
         .arg(&output_dir)
         .output()?;
@@ -104,25 +106,25 @@ fn main() -> Result<(), Report> {
         }
     }
 
-    // Generate the PDF files.
-    info!("📃 Generating PDF files...");
-    // generate_pdf(&svg_files, &output_dir)?;
-    let cmd_args_groups = build_cmd_args(
-        "inkscape",
-        &[
-            "--export-area-drawing".to_string(),
-            "--batch-process".to_string(),
-            "--export-type=pdf".to_string(),
-        ],
-        &svg_files,
-        bnacore::MAX_PROMPT_LENGTH,
-    )?;
-    for cmd_args in cmd_args_groups {
-        let mut cmd = Command::new("inkscape");
-        cmd.args(cmd_args).current_dir(&output_dir);
-        let output = cmd.output().map_err(Report::new)?;
-        process_output_with_command(&output, &cmd)?
-    }
+    // // Generate the PDF files.
+    // info!("📃 Generating PDF files...");
+    // // generate_pdf(&svg_files, &output_dir)?;
+    // let cmd_args_groups = build_cmd_args(
+    //     "inkscape",
+    //     &[
+    //         "--export-area-drawing".to_string(),
+    //         "--batch-process".to_string(),
+    //         "--export-type=pdf".to_string(),
+    //     ],
+    //     &svg_files,
+    //     bnacore::MAX_PROMPT_LENGTH,
+    // )?;
+    // for cmd_args in cmd_args_groups {
+    //     let mut cmd = Command::new("inkscape");
+    //     cmd.args(cmd_args).current_dir(&output_dir);
+    //     let output = cmd.output().map_err(Report::new)?;
+    //     process_output_with_command(&output, &cmd)?
+    // }
 
     // Append information page.
     info!("📎 Append information page");


### PR DESCRIPTION
Fixes the file name sanitizing logic to prevent special characters (like
apostrophes for instance) to land in the file name.

Drive-by:
- Updates the template version to be used.
- Switches to using `svg2pdf` instead of inkscape.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
