### PR TITLE
Add Step Machine Context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rstest = "0.18.2"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 serde_with = "3.4.0"
+time = { version = "0.3.29", features = ["serde-well-known"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.15", default-features = false, features = [

--- a/bnacore/Cargo.toml
+++ b/bnacore/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = "1.0"
-time = { version = "0.3.29", features = ["serde-well-known"] }
+time = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 walkdir = { workspace = true }

--- a/lambdas/Cargo.toml
+++ b/lambdas/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 simple-error = "0.3.0"
 svg2pdf = { "version" = "0.9.0" }
-time = { version = "0.3.29", features = ["serde-well-known"] }
+time = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
Adds Step Machine context to the metadata of the execution pipeline in
or to be able to save the execution status and pin point errors more
easily.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
