### PR TITLE
Finalize save-results step

### DIFF
--- a/bnacore/src/bundle.rs
+++ b/bnacore/src/bundle.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use walkdir::{DirEntry, WalkDir};
-use zip::ZipWriter;
+use zip::{write::SimpleFileOptions, ZipWriter};
 
 /// Define a structure to handle brochure bundles.
 pub struct Bundle {
@@ -129,7 +129,7 @@ impl Bundle {
 
         // Define the compression options.
         let options =
-            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
 
         // Zip them all.
         let all_zip_path = bundle_dir.join("all.zip");

--- a/bnacore/src/neon/model.rs
+++ b/bnacore/src/neon/model.rs
@@ -128,9 +128,7 @@ pub enum BranchState {
 #[skip_serializing_none]
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct Branch {
-    ///
     pub active_time_seconds: Option<u64>,
-    ///
     pub compute_time_seconds: Option<u64>,
     /// CPU seconds used by all the endpoints of the branch, including deleted ones.
     /// This value is reset at the beginning of each billing period.
@@ -143,7 +141,6 @@ pub struct Branch {
     pub creation_source: Option<String>,
     /// The branch state.
     pub current_state: Option<BranchState>,
-    ///
     pub data_transfer_bytes: Option<u64>,
     /// The branch ID.
     pub id: Option<String>,


### PR DESCRIPTION
Finalizes the save-results step, ensuring a city is created or updated
when new results are being saved into the database.

Drive-bys:
- Updates compression options in bundle.rs.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
