### PR TITLE
Clean up

### DIFF
--- a/lambdas/src/bna-save-results.rs
+++ b/lambdas/src/bna-save-results.rs
@@ -1,6 +1,6 @@
 use aws_config::BehaviorVersion;
 use bnacore::aws::get_aws_parameter_value;
-use bnalambdas::{authenticate_service_account, AnalysisParameters, Context};
+use bnalambdas::{authenticate_service_account, AnalysisParameters, Context, AWSS3};
 use csv::ReaderBuilder;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use reqwest::blocking::Client;
@@ -18,22 +18,6 @@ struct TaskInput {
     analysis_parameters: AnalysisParameters,
     aws_s3: AWSS3,
     context: Context,
-}
-
-#[derive(Deserialize, Serialize, Clone)]
-struct AWSS3 {
-    destination: String,
-}
-
-impl AWSS3 {
-    fn get_version(&self) -> String {
-        self.destination
-            .clone()
-            .split_terminator('/')
-            .last()
-            .unwrap()
-            .to_owned()
-    }
 }
 
 #[derive(Deserialize, Clone)]
@@ -360,7 +344,7 @@ async fn main() -> Result<(), Error> {
 mod tests {
 
     use super::*;
-    use bnalambdas::AuthResponse;
+    // use bnalambdas::AuthResponse;
 
     #[test]
     fn test_input_deserialization() {

--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -220,6 +220,22 @@ pub fn update_pipeline(
         .error_for_status()
 }
 
+#[derive(Deserialize, Serialize, Clone)]
+pub struct AWSS3 {
+    pub destination: String,
+}
+
+impl AWSS3 {
+    /// Returns the get version of this [`AWSS3`].
+    pub fn get_version(&self) -> String {
+        self.destination
+            .split_terminator('/')
+            .last()
+            .expect("the destination field must contain a `/` symbol")
+            .to_owned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Light clean up of the code base to remove duplicated structures,
      unnecessary allocations, or convert input values to contants when
      preferred.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
