### PR TITLE
Generate pipeline UUIDs

### DIFF
--- a/lambdas/src/bna-fargate-run.rs
+++ b/lambdas/src/bna-fargate-run.rs
@@ -6,7 +6,7 @@ use aws_sdk_ecs::types::{
 use bnacore::aws::get_aws_parameter_value;
 use bnalambdas::{
     authenticate_service_account, update_pipeline, AnalysisParameters, BrokenspokePipeline,
-    BrokenspokeState, Context, AWSS3,
+    BrokenspokeState, AWSS3,
 };
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,6 @@ use tracing::info;
 struct TaskInput {
     analysis_parameters: AnalysisParameters,
     aws_s3: AWSS3,
-    context: Context,
 }
 
 #[derive(Serialize)]
@@ -45,8 +44,7 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<TaskOutput, E
     // Read the task inputs.
     let aws_s3 = &event.payload.aws_s3;
     let analysis_parameters = &event.payload.analysis_parameters;
-    let state_machine_context = &event.payload.context;
-    let (state_machine_id, _) = state_machine_context.execution.ids()?;
+    let (state_machine_id, _) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
 
     // Update the pipeline status.
     let patch_url = format!("{url}/{state_machine_id}");

--- a/lambdas/src/bna-setup.rs
+++ b/lambdas/src/bna-setup.rs
@@ -4,7 +4,7 @@ use bnacore::{
 };
 use bnalambdas::{
     authenticate_service_account, update_pipeline, AnalysisParameters, BrokenspokePipeline,
-    BrokenspokeState, Context,
+    BrokenspokeState,
 };
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,6 @@ const NEON_MAX_BRANCHES: usize = 20;
 #[derive(Deserialize)]
 struct TaskInput {
     analysis_parameters: AnalysisParameters,
-    context: Context,
 }
 
 #[derive(Serialize)]
@@ -46,8 +45,7 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<TaskOutput, E
     // Read the task inputs.
     info!("Reading input...");
     let analysis_parameters = &event.payload.analysis_parameters;
-    let state_machine_context = &event.payload.context;
-    let (state_machine_id, _) = state_machine_context.execution.ids()?;
+    let (state_machine_id, _) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
 
     // Update the pipeline status.
     info!("updating pipeline...");

--- a/lambdas/src/bna-sqs-parse.rs
+++ b/lambdas/src/bna-sqs-parse.rs
@@ -40,7 +40,8 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<TaskOutput, E
     let analysis_parameters = &event.payload.messages[0].body;
     let receipt_handle = &event.payload.messages[0].receipt_handle;
     let state_machine_context = &event.payload.context;
-    let (state_machine_id, scheduled_trigger_id) = state_machine_context.execution.ids()?;
+    let (state_machine_id, scheduled_trigger_id) =
+        (uuid::Uuid::new_v4(), Some(uuid::Uuid::new_v4()));
 
     // Create a new pipeline entry.
     info!(

--- a/lambdas/src/bna-teardown.rs
+++ b/lambdas/src/bna-teardown.rs
@@ -23,7 +23,7 @@ struct Neon {
     branch_id: String,
 }
 
-async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<(), Error> {
+async fn function_handler(_event: LambdaEvent<TaskInput>) -> Result<(), Error> {
     // Retrieve API hostname.
     let api_hostname = get_aws_parameter_value("BNA_API_HOSTNAME").await?;
 
@@ -36,8 +36,7 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<(), Error> {
         .map_err(|e| format!("cannot authenticate service account: {e}"))?;
 
     // Read the task inputs.
-    let state_machine_context = &event.payload.context;
-    let (state_machine_id, _) = state_machine_context.execution.ids()?;
+    let (state_machine_id, _) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
 
     // Update the pipeline status.
     let patch_url = format!("{url}/{state_machine_id}");


### PR DESCRIPTION
Since the name of the pipelines are now human readable names, we need to
generate UUIDs to be able to store information about the progress in the
database.

This a a temporary step, and a proper patch with a schema update will
come later.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
