### PR TITLE
Retrieve ID from pipeline context

### DIFF
--- a/lambdas/src/bna-save-results.rs
+++ b/lambdas/src/bna-save-results.rs
@@ -127,7 +127,7 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<(), Error> {
     let analysis_parameters = &event.payload.analysis_parameters;
     let aws_s3 = &event.payload.aws_s3;
     let state_machine_context = &event.payload.context;
-    let (_state_machine_id, _) = state_machine_context.execution.ids()?;
+    let _state_machine_id = state_machine_context.id;
 
     info!("Retrieve secrets and parameters...");
     // Retrieve API hostname.
@@ -370,7 +370,8 @@ mod tests {
             "StateMachine": {
               "Id": "arn:aws:states:us-west-2:863246263227:stateMachine:brokenspoke-analyzer",
               "Name": "brokenspoke-analyzer"
-            }
+            },
+            "Id": "9ff90cac-0cf5-4923-897f-4416df5e7328"
           },
           "aws_s3": {
             "destination": "usa/new mexico/santa rosa/23.12.4"

--- a/lambdas/src/bna-sqs-parse.rs
+++ b/lambdas/src/bna-sqs-parse.rs
@@ -40,8 +40,7 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<TaskOutput, E
     let analysis_parameters = &event.payload.messages[0].body;
     let receipt_handle = &event.payload.messages[0].receipt_handle;
     let state_machine_context = &event.payload.context;
-    let (state_machine_id, scheduled_trigger_id) =
-        (uuid::Uuid::new_v4(), Some(uuid::Uuid::new_v4()));
+    let state_machine_id = state_machine_context.id;
 
     // Create a new pipeline entry.
     info!(
@@ -50,10 +49,8 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<TaskOutput, E
     );
     let pipeline = BrokenspokePipeline {
         state_machine_id,
-        scheduled_trigger_id,
         state: Some(BrokenspokeState::SqsMessage),
         sqs_message: Some(serde_json::to_string(analysis_parameters)?),
-
         ..Default::default()
     };
     let _post = Client::new()
@@ -112,7 +109,8 @@ fn test_input_deserialization() {
       "StateMachine": {
         "Id": "arn:aws:states:us-west-2:123456789012:stateMachine:brokenspoke-analyzer",
         "Name": "brokenspoke-analyzer"
-      }
+      },
+      "Id": "9ff90cac-0cf5-4923-897f-4416df5e7328"
     }
   }"#;
     let _deserialized = serde_json::from_str::<TaskInput>(json_input).unwrap();

--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -150,6 +150,7 @@ pub struct Context {
     pub execution: Execution,
     pub state: State,
     pub state_machine: StateMachine,
+    pub id: Uuid,
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -263,6 +264,7 @@ mod tests {
               "Id": "arn:aws:states:us-east-1:123456789012:stateMachine:stateMachineName",
               "Name": "stateMachineName"
           },
+          "Id": "9ff90cac-0cf5-4923-897f-4416df5e7328",
           "Task": {
               "Token": "h7XRiCdLtd/83p1E0dMccoxlzFhglsdkzpK9mBVKZsp7d9yrT1W"
           }


### PR DESCRIPTION
Uses the ID from the pipeline context as the state machine id/bna id.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
